### PR TITLE
fix: 修复 Linux 下启动脚本问题 (#28)

### DIFF
--- a/ClassIsland.ManagementServer.Server/setup.sh
+++ b/ClassIsland.ManagementServer.Server/setup.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/env /usr/bin/sh
+#!/usr/bin/env sh
 dotnet ./ClassIsland.ManagementServer.Server.dll --setup=true

--- a/ClassIsland.ManagementServer.Server/start.sh
+++ b/ClassIsland.ManagementServer.Server/start.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/env /usr/bin/sh
+#!/usr/bin/env sh
 dotnet ./ClassIsland.ManagementServer.Server.dll


### PR DESCRIPTION
fix: 修改Linux启动脚本以修复Linux下的启动问题(#28 )
1. 修改了启动和配置脚本中使用Windows风格换行符`\r\n`导致的启动报错
2. 修正 Shebang 写法，避免 env 查找失败（`#!/usr/bin/env sh`）
**注意：**
**修改1未必有效**，因为Windows环境默认使用`\r\n`换行而Linux下使用`\n`，使用Windows编辑此文件或使用Windows的Git客户端提交代码还是可能出现自动替换换行符。
建议直接在actions的工作流添加针对Linux相关脚本的替换（将`\r\n`替换为`\n`），可使用这条命令完成`sed -i 's/\r$//' ./setup.sh && sed -i 's/\r$//' ./start.sh`
**GPT对修改2的解释：**
原脚本使用的 Shebang 为：
```sh
#!/usr/bin/env /usr/bin/sh
```
这种写法实际上会让 `env` 去查找名为 **`/usr/bin/sh`** 的可执行文件，而不是预期的 `sh`。
在大多数系统中，`/usr/bin/sh` 只存在于文件路径中，不会作为命令出现在 `PATH` 下，因此会导致脚本直接报错：
```
/usr/bin/env: ‘/usr/bin/sh’: No such file or directory
```
隐患包括：

* 脚本无法在部分 Linux 发行版上执行；
* 不同系统上可能表现不一致（某些系统有 `/usr/bin/sh`，某些没有）；
* 降低了可移植性，不符合通用 Shebang 约定。
**修复方式：**
将 Shebang 修改为标准写法：
```sh
#!/usr/bin/env sh
```
这样 `env` 会根据环境变量 `PATH` 自动查找 `sh`，保证脚本在大多数类 Unix 系统上都能正常运行。